### PR TITLE
Update dao-permissions.php

### DIFF
--- a/dao-permissions.php
+++ b/dao-permissions.php
@@ -158,11 +158,13 @@ class Settings {
 			return;
 		}
 
+		//Added if statement to check to see if fields are empty before setting the values? Prevents a foreach warning. -JVJ 1/15/2022
+		if (! $this->dao_login_options['tokens'] == ""){
 		foreach ( $this->dao_login_options['tokens'] as $id => $values ) {
 			$this->settings_for_tracked_token( $id, $values['label'], $values );
 		}
 		$this->settings_for_tracked_token( 'new', 'New Token' );
-
+		}
 	}
 
 	public function dao_login_sanitize( $input ) {


### PR DESCRIPTION
I took a stab at trying to fix a foreach error that popped up after I added your other fix and enabled "Allow users to register based on their governance token allowance" but not entering any values right away. I think this fix may have solved the issue as the warning has gone away, but as I said before, I'm quite novice at this so definitely review the small change I made before pulling it over.


Thanks, 

James